### PR TITLE
fix: remove leaked NoteModel listener in NoteEditController

### DIFF
--- a/lib/screens/components/controllers/note_edit_controller.dart
+++ b/lib/screens/components/controllers/note_edit_controller.dart
@@ -15,15 +15,29 @@ class NoteEditController {
   final HtmlToMarkdownConverter htmlToMarkdownConverter;
   TextEditingController textController = TextEditingController();
 
+  NoteModel? _noteModel;
+  bool _disposed = false;
+
   NoteEditController({
     required this.imageService,
     required this.clipboardService,
     required this.htmlToMarkdownConverter,
   });
 
+  void _syncControllerFromModel() {
+    if (_disposed) return;
+    final noteModel = _noteModel;
+    if (noteModel == null) return;
+    if (noteModel.content != textController.text) {
+      textController.text = noteModel.content;
+    }
+  }
+
   void initialize(NoteModel noteModel, Note? note, BuildContext context) {
     // Delay the update to avoid triggering a rebuild during the build phase
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_disposed) return;
+
       if (noteModel.initialContent.isNotEmpty && note == null) {
         noteModel.content = noteModel.initialContent;
       } else if (note != null) {
@@ -33,12 +47,8 @@ class NoteEditController {
       // Set the initial text in the controller
       textController.text = noteModel.content;
 
-      // Add listener to update controller.text when noteModel.content changes
-      noteModel.addListener(() {
-        if (noteModel.content != textController.text) {
-          textController.text = noteModel.content;
-        }
-      });
+      _noteModel = noteModel;
+      noteModel.addListener(_syncControllerFromModel);
 
       // Request focus
       noteModel.requestFocus();
@@ -196,6 +206,8 @@ class NoteEditController {
   }
 
   void dispose() {
+    _disposed = true;
+    _noteModel?.removeListener(_syncControllerFromModel);
     textController.dispose();
   }
 }

--- a/lib/screens/components/controllers/note_edit_controller.dart
+++ b/lib/screens/components/controllers/note_edit_controller.dart
@@ -34,6 +34,7 @@ class NoteEditController {
   }
 
   void initialize(NoteModel noteModel, Note? note, BuildContext context) {
+    assert(_noteModel == null, 'NoteEditController.initialize() must not be called more than once');
     // Delay the update to avoid triggering a rebuild during the build phase
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_disposed) return;
@@ -208,6 +209,7 @@ class NoteEditController {
   void dispose() {
     _disposed = true;
     _noteModel?.removeListener(_syncControllerFromModel);
+    _noteModel = null;
     textController.dispose();
   }
 }

--- a/test/controllers/note_edit_controller_test.dart
+++ b/test/controllers/note_edit_controller_test.dart
@@ -357,6 +357,9 @@ void main() {
       ));
       await tester.pump(); // callback fires but should be a no-op
 
+      // setUploading(true) changes state and fires notifyListeners — the
+      // listener must not touch the disposed textController.
+      expect(() => noteModel.setUploading(true), returnsNormally);
       expect(() => noteModel.setUploading(false), returnsNormally);
     });
   });

--- a/test/controllers/note_edit_controller_test.dart
+++ b/test/controllers/note_edit_controller_test.dart
@@ -314,4 +314,50 @@ void main() {
       expect(noteModel.isPasting, isFalse);
     });
   });
+
+  group('NoteEditController listener lifecycle', () {
+    late NoteEditController controller;
+
+    setUp(() {
+      controller = NoteEditController(
+        imageService: FakeImageService(),
+        clipboardService: FakeClipboardService(),
+        htmlToMarkdownConverter: HtmlToMarkdownConverter(),
+      );
+    });
+
+    testWidgets('post-dispose notifyListeners does not throw', (tester) async {
+      final noteModel = NoteModel();
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(builder: (ctx) {
+          controller.initialize(noteModel, null, ctx);
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump(); // allow addPostFrameCallback to fire
+
+      controller.dispose();
+
+      // Simulates in-flight upload/paste completing after navigation away
+      expect(() => noteModel.setUploading(true), returnsNormally);
+      expect(() => noteModel.setUploading(false), returnsNormally);
+      expect(() => noteModel.setPasting(true), returnsNormally);
+      expect(() => noteModel.setPasting(false), returnsNormally);
+    });
+
+    testWidgets('dispose before frame callback does not throw', (tester) async {
+      final noteModel = NoteModel();
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(builder: (ctx) {
+          controller.initialize(noteModel, null, ctx);
+          // dispose immediately, before the frame callback fires
+          controller.dispose();
+          return const SizedBox();
+        }),
+      ));
+      await tester.pump(); // callback fires but should be a no-op
+
+      expect(() => noteModel.setUploading(false), returnsNormally);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Extracts the anonymous listener in `NoteEditController.initialize()` to a named `_syncControllerFromModel` method so it can be removed in `dispose()`
- Stores the `NoteModel` reference and calls `removeListener` before `textController.dispose()`
- Guards the `addPostFrameCallback` body with `_disposed` to handle the race where `dispose()` runs before the frame callback fires

## Test plan
- [x] `flutter test test/controllers/note_edit_controller_test.dart` — 12 tests pass (2 new regression tests added)
- [x] `flutter analyze` — no issues
- [x] New test: post-dispose `setUploading(true/false)` and `setPasting(true/false)` do not throw
- [x] New test: dispose-before-frame-callback path is a no-op

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)