### PR TITLE
fix: replace TagController.dispose() misuse with closeOverlay() method

### DIFF
--- a/lib/screens/components/controllers/tag_controller.dart
+++ b/lib/screens/components/controllers/tag_controller.dart
@@ -10,6 +10,7 @@ class TagController {
   final NoteEditController noteEditController;
   OverlayEntry? _tagListOverlay;
   Timer? _tagListTimer;
+  bool _disposed = false;
 
   TagController({required this.noteTagService, required this.noteEditController});
 
@@ -23,11 +24,7 @@ class TagController {
         showTagList(noteModel, text, cursorPosition, context);
       });
     } else {
-      _tagListTimer?.cancel();
-      if (_tagListOverlay != null) {
-        _tagListOverlay?.remove();
-        _tagListOverlay = null;
-      }
+      closeOverlay();
     }
   }
 
@@ -66,9 +63,15 @@ class TagController {
     return TextSelection.fromPosition(TextPosition(offset: newCursorPosition));
   }
 
-  void dispose() {
+  void closeOverlay() {
     _tagListTimer?.cancel();
     _tagListOverlay?.remove();
     _tagListOverlay = null;
+  }
+
+  void dispose() {
+    assert(!_disposed, 'TagController.dispose() called more than once');
+    _disposed = true;
+    closeOverlay();
   }
 }

--- a/lib/screens/components/controllers/tag_controller.dart
+++ b/lib/screens/components/controllers/tag_controller.dart
@@ -69,6 +69,7 @@ class TagController {
     _tagListOverlay = null;
   }
 
+  // assert fires in debug builds only; use closeOverlay() for runtime close operations.
   void dispose() {
     assert(!_disposed, 'TagController.dispose() called more than once');
     _disposed = true;

--- a/lib/screens/components/note_edit.dart
+++ b/lib/screens/components/note_edit.dart
@@ -217,7 +217,7 @@ class NoteEditState extends State<NoteEdit> {
       },
       child: Listener(
         onPointerDown: (event) {
-          tagController.dispose(); // Close tag overlay if open
+          tagController.closeOverlay();
         },
         child: AnimatedBuilder(
           animation: noteModel.focusNode,

--- a/test/controllers/tag_controller_test.dart
+++ b/test/controllers/tag_controller_test.dart
@@ -1,0 +1,68 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:happy_notes/apis/file_uploader_api.dart';
+import 'package:happy_notes/apis/note_tag_api.dart';
+import 'package:happy_notes/screens/components/controllers/html_to_markdown_converter.dart';
+import 'package:happy_notes/screens/components/controllers/note_edit_controller.dart';
+import 'package:happy_notes/screens/components/controllers/tag_controller.dart';
+import 'package:happy_notes/services/clipboard_service.dart';
+import 'package:happy_notes/services/image_service.dart';
+import 'package:happy_notes/services/note_tag_service.dart';
+
+class _FakeNoteTagApi extends NoteTagApi {
+  @override
+  Future<Response<dynamic>> getMyTagCloud() async =>
+      Response(requestOptions: RequestOptions(), data: {'successful': true, 'data': []});
+}
+
+class _FakeImageService extends ImageService {
+  _FakeImageService() : super(fileUploaderApi: FileUploaderApi());
+}
+
+TagController _makeTagController(NoteEditController noteEditController) {
+  return TagController(
+    noteTagService: NoteTagService(noteTagApi: _FakeNoteTagApi()),
+    noteEditController: noteEditController,
+  );
+}
+
+NoteEditController _makeNoteEditController() {
+  return NoteEditController(
+    imageService: _FakeImageService(),
+    clipboardService: ClipboardService(),
+    htmlToMarkdownConverter: HtmlToMarkdownConverter(),
+  );
+}
+
+void main() {
+  group('TagController.closeOverlay', () {
+    late NoteEditController noteEditController;
+    late TagController tagController;
+
+    setUp(() {
+      noteEditController = _makeNoteEditController();
+      tagController = _makeTagController(noteEditController);
+    });
+
+    tearDown(() {
+      tagController.dispose();
+      noteEditController.dispose();
+    });
+
+    test('closeOverlay is a no-op when no overlay is open', () {
+      expect(() => tagController.closeOverlay(), returnsNormally);
+    });
+
+    test('closeOverlay can be called multiple times without throwing', () {
+      tagController.closeOverlay();
+      tagController.closeOverlay();
+      tagController.closeOverlay();
+    });
+
+    test('dispose throws AssertionError if called a second time', () {
+      final ctrl = _makeTagController(noteEditController);
+      ctrl.dispose();
+      expect(() => ctrl.dispose(), throwsA(isA<AssertionError>()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `closeOverlay()` to `TagController` as the correct API for runtime close operations — timer cancel + overlay remove, callable any number of times
- `dispose()` delegates to `closeOverlay()` and asserts it is only called once (debug-mode guard against future fragility)
- Updates `Listener.onPointerDown` in `note_edit.dart` from `dispose()` to `closeOverlay()`
- Consolidates the duplicate inline close logic in `handleTextChanged()` to call `closeOverlay()`

## Test plan
- [x] `flutter test test/controllers/tag_controller_test.dart` — 3 new tests pass (no-op on empty, idempotent multiple calls, second dispose asserts)
- [x] `flutter analyze` — no issues

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)